### PR TITLE
[提案]フォームの値とクエリストリングを同期させてはどうでしょうか？

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import KimochiiiRadarChart from './components/KimochiiiRadarChart';
 import KimochiiiSlider from './components/KimochiiiSlider';
 import KimochiiiFooter from './components/KimochiiiFooter';
+import { useQueryState } from './useQueryState';
 import Box from '@mui/material/Box';
 import Grid from '@mui/system/Grid';
 import TextField from '@mui/material/TextField';
@@ -44,14 +45,11 @@ const axises = [
 ];
 
 const App = () => {
-  const [name, setName] = useState(localStorage.getItem('name'));
-  let storedValues = localStorage.getItem('values');
-  storedValues = storedValues ? JSON.parse(storedValues).map((n) => Number(n)) : null;
-  const [values, setValues] = useState(storedValues || axises.map((axis) => axis.defaultValue));
+  const [name, setName] = useQueryState('name');
+  const [values, setValues] = useQueryState('values', axises.map((axis) => axis.defaultValue));
   const setValueAt = (index) => (value) => {
     const newValues = [...values];
     newValues[index] = value;
-    localStorage.setItem('values', JSON.stringify(newValues));
     setValues(newValues);
   };
 
@@ -68,7 +66,6 @@ const App = () => {
               defaultValue={name}
               onChange={(e) => {
                 const { value } = e.currentTarget;
-                localStorage.setItem('name', value);
                 setName(value);
               }}
             />

--- a/src/useQueryState.js
+++ b/src/useQueryState.js
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+
+export const useQueryState = (paramName, initialValue) => {
+  const [value, setValue] = useState(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    const paramValue = searchParams.get(paramName);
+
+    return paramValue !== null ? JSON.parse(paramValue) : initialValue;
+  });
+
+  useEffect(() => {
+    const currentSearchParams = new URLSearchParams(window.location.search);
+
+    if (value) {
+      currentSearchParams.set(paramName, JSON.stringify(value));
+    } else {
+      currentSearchParams.delete(paramName);
+    }
+
+    const newUrl = [window.location.pathname, currentSearchParams.toString()].filter(Boolean).join('?');
+
+    window.history.replaceState(window.history.state, '', newUrl);
+  }, [paramName, value]);
+
+  return [value, setValue];
+};


### PR DESCRIPTION
（ルールが不明だったので日本語で失礼します！）

簡易的にフォームの値を共有しやすくするために、クエリストリングを使用してはどうかなと考えました。
ただし完璧な同期ではなく、クエリストリングからフォームに反映されるのはページロード時だけであり、ページロード後にクエリストリングを直接変更してもフォームには反映されません。
この辺を完璧にするには react-router-dom 等を使用すればよいと思います。

ちょっとした思いつきなので、イマイチだったら気軽に却下してもらって大丈夫です 🙆‍♂️ 
